### PR TITLE
Add ASP.NET Core currency conversion API

### DIFF
--- a/CurrencyConversion.sln
+++ b/CurrencyConversion.sln
@@ -1,0 +1,26 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CurrencyConversion.Api", "src/CurrencyConversion.Api/CurrencyConversion.Api.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CurrencyConversion.Tests", "tests/CurrencyConversion.Tests/CurrencyConversion.Tests.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal
+

--- a/README.md
+++ b/README.md
@@ -1,31 +1,39 @@
-# Currency Conversion
+# Currency Conversion API
 
-貨幣轉換應用程式
+This project provides a simple ASP.NET Core Web API for recording and querying currency exchange rates.
 
-## 功能特色
+## Prerequisites
 
-- 支援多種貨幣轉換
-- 即時匯率更新
-- 用戶友好的介面
+- .NET 7 SDK
+- Microsoft SQL Server
 
-## 安裝說明
+## Setup
+
+1. Restore packages and create database migrations:
 
 ```bash
-# 克隆專案
-git clone https://github.com/QuennelChen/CurrencyConversion.git
-
-# 進入專案目錄
-cd CurrencyConversion
+dotnet restore
+cd src/CurrencyConversion.Api
+dotnet ef migrations add InitialCreate
 ```
 
-## 使用方法
+2. Apply migrations and run the API:
 
-待開發...
+```bash
+dotnet ef database update
+dotnet run
+```
 
-## 貢獻
+The daily synchronization job runs at the time specified in `appsettings.json` under `Schedule:DailyTime`.
 
-歡迎提交 Pull Request 或回報問題。
+## Configuration
 
-## 授權
+`appsettings.json` contains placeholders for database connection string, external API key and authentication options. Replace them with your actual values before running the application.
 
-MIT License
+## Testing
+
+Example unit tests reside in `tests/CurrencyConversion.Tests`. Execute them with:
+
+```bash
+dotnet test
+```

--- a/src/CurrencyConversion.Api/Controllers/CurrenciesController.cs
+++ b/src/CurrencyConversion.Api/Controllers/CurrenciesController.cs
@@ -1,0 +1,21 @@
+using CurrencyConversion.Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CurrencyConversion.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class CurrenciesController : ControllerBase
+{
+    private readonly IExchangeRateService _service;
+    public CurrenciesController(IExchangeRateService service) => _service = service;
+
+    [HttpGet]
+    public async Task<IActionResult> Get()
+    {
+        var currencies = await _service.GetCurrenciesAsync();
+        return Ok(currencies.Select(c => new { c.Code, c.Name }));
+    }
+}

--- a/src/CurrencyConversion.Api/Controllers/ExchangeRateController.cs
+++ b/src/CurrencyConversion.Api/Controllers/ExchangeRateController.cs
@@ -1,0 +1,48 @@
+using CurrencyConversion.Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CurrencyConversion.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class ExchangeRateController : ControllerBase
+{
+    private readonly IExchangeRateService _service;
+    public ExchangeRateController(IExchangeRateService service) => _service = service;
+
+    [HttpGet]
+    public async Task<IActionResult> Get([FromQuery] string from, [FromQuery] string to)
+    {
+        var result = await _service.GetLatestRateAsync(from, to);
+        if (result == null) return BadRequest("Invalid currency code");
+        var (log, fromCur, toCur) = result.Value;
+        return Ok(new
+        {
+            from = fromCur.Code,
+            to = toCur.Code,
+            rate = log.Rate,
+            timestamp = log.RetrievedAt
+        });
+    }
+
+    public record ConvertRequest(string From, string To, decimal Amount);
+
+    [HttpPost("convert")]
+    public async Task<IActionResult> Convert([FromBody] ConvertRequest request)
+    {
+        var result = await _service.ConvertAsync(request.From, request.To, request.Amount);
+        if (result == null) return BadRequest("Invalid currency code");
+        var (converted, log, fromCur, toCur) = result.Value;
+        return Ok(new
+        {
+            from = fromCur.Code,
+            to = toCur.Code,
+            amount = request.Amount,
+            convertedAmount = converted,
+            rate = log.Rate,
+            timestamp = log.RetrievedAt
+        });
+    }
+}

--- a/src/CurrencyConversion.Api/CurrencyConversion.Api.csproj
+++ b/src/CurrencyConversion.Api/CurrencyConversion.Api.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/CurrencyConversion.Api/Data/AppDbContext.cs
+++ b/src/CurrencyConversion.Api/Data/AppDbContext.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using CurrencyConversion.Api.Models;
+
+namespace CurrencyConversion.Api.Data;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
+    public DbSet<Currency> Currencies => Set<Currency>();
+    public DbSet<ExchangeRateLog> ExchangeRateLogs => Set<ExchangeRateLog>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Currency>(entity =>
+        {
+            entity.HasIndex(e => e.Code).IsUnique();
+            entity.Property(e => e.Code).HasMaxLength(3).IsRequired();
+            entity.Property(e => e.Name).HasMaxLength(50).IsRequired();
+        });
+
+        modelBuilder.Entity<ExchangeRateLog>(entity =>
+        {
+            entity.Property(e => e.Rate).HasColumnType("decimal(18,6)");
+            entity.HasOne(e => e.BaseCurrency)
+                .WithMany(c => c.BaseRateLogs)
+                .HasForeignKey(e => e.BaseCurrencyId);
+            entity.HasOne(e => e.TargetCurrency)
+                .WithMany(c => c.TargetRateLogs)
+                .HasForeignKey(e => e.TargetCurrencyId);
+        });
+    }
+}

--- a/src/CurrencyConversion.Api/HostedServices/DailySyncService.cs
+++ b/src/CurrencyConversion.Api/HostedServices/DailySyncService.cs
@@ -1,0 +1,84 @@
+using CurrencyConversion.Api.Models;
+using CurrencyConversion.Api.Options;
+using CurrencyConversion.Api.Repositories;
+using CurrencyConversion.Api.Services;
+using Microsoft.Extensions.Options;
+
+namespace CurrencyConversion.Api.HostedServices;
+
+public class DailySyncService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptions<ScheduleOptions> _scheduleOptions;
+    private readonly ILogger<DailySyncService> _logger;
+    private readonly IExternalRateProvider _provider;
+
+    public DailySyncService(IServiceScopeFactory scopeFactory,
+        IOptions<ScheduleOptions> scheduleOptions,
+        ILogger<DailySyncService> logger,
+        IExternalRateProvider provider)
+    {
+        _scopeFactory = scopeFactory;
+        _scheduleOptions = scheduleOptions;
+        _logger = logger;
+        _provider = provider;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var delay = GetDelay();
+            await Task.Delay(delay, stoppingToken);
+            await SyncRatesAsync(stoppingToken);
+        }
+    }
+
+    private TimeSpan GetDelay()
+    {
+        if (TimeSpan.TryParse(_scheduleOptions.Value.DailyTime, out var time))
+        {
+            var next = DateTime.Today.Add(time);
+            if (next < DateTime.Now)
+            {
+                next = next.AddDays(1);
+            }
+            return next - DateTime.Now;
+        }
+        return TimeSpan.FromHours(24);
+    }
+
+    private async Task SyncRatesAsync(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var currencyRepo = scope.ServiceProvider.GetRequiredService<ICurrencyRepository>();
+        var logRepo = scope.ServiceProvider.GetRequiredService<IExchangeRateLogRepository>();
+        try
+        {
+            var currencies = await currencyRepo.GetAllAsync();
+            foreach (var baseCurrency in currencies)
+            {
+                var rates = await _provider.GetRatesAsync(baseCurrency.Code);
+                foreach (var target in currencies)
+                {
+                    if (baseCurrency.Code == target.Code || !rates.TryGetValue(target.Code, out var rate))
+                        continue;
+                    var log = new ExchangeRateLog
+                    {
+                        BaseCurrencyId = baseCurrency.Id,
+                        TargetCurrencyId = target.Id,
+                        Rate = rate,
+                        RetrievedAt = DateTime.UtcNow
+                    };
+                    await logRepo.AddAsync(log);
+                }
+            }
+            await logRepo.SaveChangesAsync();
+            _logger.LogInformation("Exchange rates synced successfully at {time}", DateTime.UtcNow);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error syncing exchange rates");
+        }
+    }
+}

--- a/src/CurrencyConversion.Api/Models/Currency.cs
+++ b/src/CurrencyConversion.Api/Models/Currency.cs
@@ -1,0 +1,10 @@
+namespace CurrencyConversion.Api.Models;
+
+public class Currency
+{
+    public int Id { get; set; }
+    public string Code { get; set; } = null!;
+    public string Name { get; set; } = null!;
+    public ICollection<ExchangeRateLog> BaseRateLogs { get; set; } = new List<ExchangeRateLog>();
+    public ICollection<ExchangeRateLog> TargetRateLogs { get; set; } = new List<ExchangeRateLog>();
+}

--- a/src/CurrencyConversion.Api/Models/ExchangeRateLog.cs
+++ b/src/CurrencyConversion.Api/Models/ExchangeRateLog.cs
@@ -1,0 +1,13 @@
+namespace CurrencyConversion.Api.Models;
+
+public class ExchangeRateLog
+{
+    public int Id { get; set; }
+    public int BaseCurrencyId { get; set; }
+    public int TargetCurrencyId { get; set; }
+    public decimal Rate { get; set; }
+    public DateTime RetrievedAt { get; set; }
+
+    public Currency? BaseCurrency { get; set; }
+    public Currency? TargetCurrency { get; set; }
+}

--- a/src/CurrencyConversion.Api/Options/AuthOptions.cs
+++ b/src/CurrencyConversion.Api/Options/AuthOptions.cs
@@ -1,0 +1,9 @@
+namespace CurrencyConversion.Api.Options;
+
+public class AuthOptions
+{
+    public const string SectionName = "Authentication";
+    public string Scheme { get; set; } = "ApiKey"; // or Jwt
+    public string? ApiKey { get; set; }
+    public string? JwtSecret { get; set; }
+}

--- a/src/CurrencyConversion.Api/Options/ExternalApiOptions.cs
+++ b/src/CurrencyConversion.Api/Options/ExternalApiOptions.cs
@@ -1,0 +1,8 @@
+namespace CurrencyConversion.Api.Options;
+
+public class ExternalApiOptions
+{
+    public const string SectionName = "ExternalApi";
+    public string BaseUrl { get; set; } = "https://api.exchangerate.host/";
+    public string? ApiKey { get; set; }
+}

--- a/src/CurrencyConversion.Api/Options/ScheduleOptions.cs
+++ b/src/CurrencyConversion.Api/Options/ScheduleOptions.cs
@@ -1,0 +1,7 @@
+namespace CurrencyConversion.Api.Options;
+
+public class ScheduleOptions
+{
+    public const string SectionName = "Schedule";
+    public string DailyTime { get; set; } = "02:00"; // HH:mm
+}

--- a/src/CurrencyConversion.Api/Program.cs
+++ b/src/CurrencyConversion.Api/Program.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.Options;
+using CurrencyConversion.Api.Data;
+using CurrencyConversion.Api.HostedServices;
+using CurrencyConversion.Api.Options;
+using CurrencyConversion.Api.Repositories;
+using CurrencyConversion.Api.Security;
+using CurrencyConversion.Api.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+builder.Services.Configure<ExternalApiOptions>(builder.Configuration.GetSection(ExternalApiOptions.SectionName));
+builder.Services.Configure<ScheduleOptions>(builder.Configuration.GetSection(ScheduleOptions.SectionName));
+builder.Services.Configure<AuthOptions>(builder.Configuration.GetSection(AuthOptions.SectionName));
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("Default")));
+
+builder.Services.AddScoped<ICurrencyRepository, CurrencyRepository>();
+builder.Services.AddScoped<IExchangeRateLogRepository, ExchangeRateLogRepository>();
+builder.Services.AddScoped<IExchangeRateService, ExchangeRateService>();
+
+builder.Services.AddHttpClient<IExternalRateProvider, ExchangeRateHostProvider>((sp, client) =>
+{
+    var opts = sp.GetRequiredService<IOptions<ExternalApiOptions>>().Value;
+    client.BaseAddress = new Uri(opts.BaseUrl);
+    if (!string.IsNullOrEmpty(opts.ApiKey))
+        client.DefaultRequestHeaders.Add("apikey", opts.ApiKey);
+});
+
+builder.Services.AddHostedService<DailySyncService>();
+
+var authOptions = builder.Configuration.GetSection(AuthOptions.SectionName).Get<AuthOptions>();
+if (authOptions?.Scheme == "Jwt")
+{
+    builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        .AddJwtBearer(options =>
+        {
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = false,
+                ValidateAudience = false,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(System.Text.Encoding.UTF8.GetBytes(authOptions.JwtSecret ?? "secret"))
+            };
+        });
+}
+else
+{
+    builder.Services.AddAuthentication("ApiKey");
+}
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Currency API", Version = "v1" });
+});
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.Migrate();
+}
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
+app.UseMiddleware<ApiKeyMiddleware>();
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/src/CurrencyConversion.Api/Repositories/CurrencyRepository.cs
+++ b/src/CurrencyConversion.Api/Repositories/CurrencyRepository.cs
@@ -1,0 +1,16 @@
+using CurrencyConversion.Api.Data;
+using CurrencyConversion.Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CurrencyConversion.Api.Repositories;
+
+public class CurrencyRepository : ICurrencyRepository
+{
+    private readonly AppDbContext _context;
+    public CurrencyRepository(AppDbContext context) => _context = context;
+
+    public async Task<IEnumerable<Currency>> GetAllAsync() => await _context.Currencies.AsNoTracking().ToListAsync();
+
+    public async Task<Currency?> GetByCodeAsync(string code) =>
+        await _context.Currencies.FirstOrDefaultAsync(c => c.Code == code);
+}

--- a/src/CurrencyConversion.Api/Repositories/ExchangeRateLogRepository.cs
+++ b/src/CurrencyConversion.Api/Repositories/ExchangeRateLogRepository.cs
@@ -1,0 +1,29 @@
+using CurrencyConversion.Api.Data;
+using CurrencyConversion.Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CurrencyConversion.Api.Repositories;
+
+public class ExchangeRateLogRepository : IExchangeRateLogRepository
+{
+    private readonly AppDbContext _context;
+    public ExchangeRateLogRepository(AppDbContext context) => _context = context;
+
+    public async Task<ExchangeRateLog?> GetLatestRateAsync(int baseCurrencyId, int targetCurrencyId)
+    {
+        return await _context.ExchangeRateLogs
+            .Where(e => e.BaseCurrencyId == baseCurrencyId && e.TargetCurrencyId == targetCurrencyId)
+            .OrderByDescending(e => e.RetrievedAt)
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task AddAsync(ExchangeRateLog log)
+    {
+        await _context.ExchangeRateLogs.AddAsync(log);
+    }
+
+    public async Task SaveChangesAsync()
+    {
+        await _context.SaveChangesAsync();
+    }
+}

--- a/src/CurrencyConversion.Api/Repositories/ICurrencyRepository.cs
+++ b/src/CurrencyConversion.Api/Repositories/ICurrencyRepository.cs
@@ -1,0 +1,9 @@
+using CurrencyConversion.Api.Models;
+
+namespace CurrencyConversion.Api.Repositories;
+
+public interface ICurrencyRepository
+{
+    Task<IEnumerable<Currency>> GetAllAsync();
+    Task<Currency?> GetByCodeAsync(string code);
+}

--- a/src/CurrencyConversion.Api/Repositories/IExchangeRateLogRepository.cs
+++ b/src/CurrencyConversion.Api/Repositories/IExchangeRateLogRepository.cs
@@ -1,0 +1,10 @@
+using CurrencyConversion.Api.Models;
+
+namespace CurrencyConversion.Api.Repositories;
+
+public interface IExchangeRateLogRepository
+{
+    Task<ExchangeRateLog?> GetLatestRateAsync(int baseCurrencyId, int targetCurrencyId);
+    Task AddAsync(ExchangeRateLog log);
+    Task SaveChangesAsync();
+}

--- a/src/CurrencyConversion.Api/Security/ApiKeyMiddleware.cs
+++ b/src/CurrencyConversion.Api/Security/ApiKeyMiddleware.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using CurrencyConversion.Api.Options;
+
+namespace CurrencyConversion.Api.Security;
+
+public class ApiKeyMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly AuthOptions _options;
+
+    public ApiKeyMiddleware(RequestDelegate next, IOptions<AuthOptions> options)
+    {
+        _next = next;
+        _options = options.Value;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (_options.Scheme != "ApiKey")
+        {
+            await _next(context);
+            return;
+        }
+
+        if (!context.Request.Headers.TryGetValue("X-Api-Key", out var key) || key != _options.ApiKey)
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Invalid API Key");
+            return;
+        }
+        await _next(context);
+    }
+}

--- a/src/CurrencyConversion.Api/Services/ExchangeRateHostProvider.cs
+++ b/src/CurrencyConversion.Api/Services/ExchangeRateHostProvider.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+
+namespace CurrencyConversion.Api.Services;
+
+public class ExchangeRateHostProvider : IExternalRateProvider
+{
+    private readonly HttpClient _client;
+    public ExchangeRateHostProvider(HttpClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<Dictionary<string, decimal>> GetRatesAsync(string baseCurrencyCode)
+    {
+        var response = await _client.GetAsync($"latest?base={baseCurrencyCode}");
+        response.EnsureSuccessStatusCode();
+        using var stream = await response.Content.ReadAsStreamAsync();
+        var doc = await JsonDocument.ParseAsync(stream);
+        var rates = new Dictionary<string, decimal>();
+        if (doc.RootElement.TryGetProperty("rates", out var ratesElem))
+        {
+            foreach (var rate in ratesElem.EnumerateObject())
+            {
+                rates[rate.Name] = rate.Value.GetDecimal();
+            }
+        }
+        return rates;
+    }
+}

--- a/src/CurrencyConversion.Api/Services/ExchangeRateService.cs
+++ b/src/CurrencyConversion.Api/Services/ExchangeRateService.cs
@@ -1,0 +1,37 @@
+using CurrencyConversion.Api.Models;
+using CurrencyConversion.Api.Repositories;
+
+namespace CurrencyConversion.Api.Services;
+
+public class ExchangeRateService : IExchangeRateService
+{
+    private readonly ICurrencyRepository _currencyRepo;
+    private readonly IExchangeRateLogRepository _logRepo;
+
+    public ExchangeRateService(ICurrencyRepository currencyRepo, IExchangeRateLogRepository logRepo)
+    {
+        _currencyRepo = currencyRepo;
+        _logRepo = logRepo;
+    }
+
+    public async Task<IEnumerable<Currency>> GetCurrenciesAsync() => await _currencyRepo.GetAllAsync();
+
+    public async Task<(ExchangeRateLog log, Currency from, Currency to)?> GetLatestRateAsync(string fromCode, string toCode)
+    {
+        var from = await _currencyRepo.GetByCodeAsync(fromCode);
+        var to = await _currencyRepo.GetByCodeAsync(toCode);
+        if (from == null || to == null) return null;
+        var log = await _logRepo.GetLatestRateAsync(from.Id, to.Id);
+        if (log == null) return null;
+        return (log, from, to);
+    }
+
+    public async Task<(decimal converted, ExchangeRateLog log, Currency from, Currency to)?> ConvertAsync(string fromCode, string toCode, decimal amount)
+    {
+        var result = await GetLatestRateAsync(fromCode, toCode);
+        if (result == null) return null;
+        var (log, from, to) = result.Value;
+        var converted = amount * log.Rate;
+        return (converted, log, from, to);
+    }
+}

--- a/src/CurrencyConversion.Api/Services/IExchangeRateService.cs
+++ b/src/CurrencyConversion.Api/Services/IExchangeRateService.cs
@@ -1,0 +1,10 @@
+using CurrencyConversion.Api.Models;
+
+namespace CurrencyConversion.Api.Services;
+
+public interface IExchangeRateService
+{
+    Task<IEnumerable<Currency>> GetCurrenciesAsync();
+    Task<(ExchangeRateLog log, Currency from, Currency to)?> GetLatestRateAsync(string fromCode, string toCode);
+    Task<(decimal converted, ExchangeRateLog log, Currency from, Currency to)?> ConvertAsync(string fromCode, string toCode, decimal amount);
+}

--- a/src/CurrencyConversion.Api/Services/IExternalRateProvider.cs
+++ b/src/CurrencyConversion.Api/Services/IExternalRateProvider.cs
@@ -1,0 +1,6 @@
+namespace CurrencyConversion.Api.Services;
+
+public interface IExternalRateProvider
+{
+    Task<Dictionary<string, decimal>> GetRatesAsync(string baseCurrencyCode);
+}

--- a/src/CurrencyConversion.Api/appsettings.json
+++ b/src/CurrencyConversion.Api/appsettings.json
@@ -1,0 +1,24 @@
+{
+  "ConnectionStrings": {
+    "Default": "Server=(localdb)\\mssqllocaldb;Database=CurrencyDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "ExternalApi": {
+    "BaseUrl": "https://api.exchangerate.host/",
+    "ApiKey": "YOUR_API_KEY"
+  },
+  "Schedule": {
+    "DailyTime": "02:00"
+  },
+  "Authentication": {
+    "Scheme": "ApiKey",
+    "ApiKey": "REPLACE_WITH_KEY",
+    "JwtSecret": "REPLACE_WITH_SECRET"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/tests/CurrencyConversion.Tests/CurrencyConversion.Tests.csproj
+++ b/tests/CurrencyConversion.Tests/CurrencyConversion.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/CurrencyConversion.Api/CurrencyConversion.Api.csproj" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/CurrencyConversion.Tests/ExchangeRateServiceTests.cs
+++ b/tests/CurrencyConversion.Tests/ExchangeRateServiceTests.cs
@@ -1,0 +1,34 @@
+using CurrencyConversion.Api.Models;
+using CurrencyConversion.Api.Repositories;
+using CurrencyConversion.Api.Services;
+using Moq;
+using Xunit;
+
+namespace CurrencyConversion.Tests;
+
+public class ExchangeRateServiceTests
+{
+    [Fact]
+    public async Task ConvertAsync_ReturnsConvertedAmount()
+    {
+        var currencyRepo = new Mock<ICurrencyRepository>();
+        var logRepo = new Mock<IExchangeRateLogRepository>();
+
+        currencyRepo.Setup(r => r.GetByCodeAsync("USD")).ReturnsAsync(new Currency { Id = 1, Code = "USD", Name = "US Dollar" });
+        currencyRepo.Setup(r => r.GetByCodeAsync("TWD")).ReturnsAsync(new Currency { Id = 2, Code = "TWD", Name = "Taiwan Dollar" });
+        logRepo.Setup(r => r.GetLatestRateAsync(1, 2)).ReturnsAsync(new ExchangeRateLog
+        {
+            BaseCurrencyId = 1,
+            TargetCurrencyId = 2,
+            Rate = 30m,
+            RetrievedAt = DateTime.UtcNow
+        });
+
+        var service = new ExchangeRateService(currencyRepo.Object, logRepo.Object);
+
+        var result = await service.ConvertAsync("USD", "TWD", 2);
+
+        Assert.NotNull(result);
+        Assert.Equal(60m, result?.converted);
+    }
+}


### PR DESCRIPTION
## Summary
- implement API controllers, services, repositories and EF Core context
- add background service for daily sync from external provider
- provide API key/JWT options and configuration classes
- include sample xUnit test for exchange rate service
- document setup steps in README

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523f89c1c8832487098f441052c66d